### PR TITLE
Fix OpenSSL cross-compilation error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,6 +1908,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,6 +2250,15 @@ dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
  "syn 1.0.82",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -3958,6 +3976,7 @@ dependencies = [
  "multimap",
  "nl80211",
  "num_enum",
+ "objc",
  "openssl",
  "os_info",
  "owning_ref",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ crypto-hashes = "0.9.0"
 sha-1 = "0.9.8"
 rust-crypto = "0.2.36"
 rsa = "0.5.0"
-openssl = "0.10.38"
+openssl = {version = "0.10.38", features = ["vendored"]}
 tar = "0.4.37"
 bzip2 = "0.4.3"
 enum-utils = "0.1.2"
@@ -93,6 +93,9 @@ winapi = { version = "0.3.9", features = ["winuser", "processthreadsapi","handle
 x11rb = { version = "0.9.0", features = ["screensaver"] }
 xcb = "0.10.1"
 nl80211 = {git="https://github.com/Eonm/nl80211", branch="master"}
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc = "0.2.7"
 
 [features]
 sync = ["datachannel"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ crypto-hashes = "0.9.0"
 sha-1 = "0.9.8"
 rust-crypto = "0.2.36"
 rsa = "0.5.0"
-openssl = {version = "0.10.38", features = ["vendored"]}
+openssl = "0.10.38"
 tar = "0.4.37"
 bzip2 = "0.4.3"
 enum-utils = "0.1.2"
@@ -99,6 +99,7 @@ objc = "0.2.7"
 
 [features]
 sync = ["datachannel"]
+openssl-vendored = ["openssl/vendored"]
 
 [profile.dev.package."*"]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ You should start `timetrackrs` on user login. It will start the UI at <http://lo
 
 If you use systemd, you can use the included [timetrackrs.service] service file to auto-start timetrackrs.
 
+Note for building in **Windows**: If you're experiencing an error related to `openssl-sys` either install the **OpenSSL Library** properly via `vcpk` or add the `--features openssl-vendored` argument to the installation command, such as:
+
+```bash
+#build and install `timetrackrs` binary to ~/.cargo/bin
+cargo install --features openssl-vendored --path .
+```
+
 **Development**
 
 To start a timetrackrs server (backend + frontend) without any capturing, you can run


### PR DESCRIPTION
Just enabled the OpenSSL's "vendored" feature, which fixes cross-compilation errors related to it.

You can refer [this](https://lib.rs/crates/openssl) and search for "Vendored".

Also added **objc** dependency for **OSX** builds, which will be used to interface with the Objective-C runtime and thus Apple's AppKit APIs.