### PR TITLE
Fix cross-compilation error

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,7 @@
 fn main(){
-    if cfg!(target_os = "macos"){
+    let target = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+
+    if target == "macos" {
         println!("cargo:rustc-link-lib=framework=AppKit");
     }
 }


### PR DESCRIPTION
`cfg!` refers to the target that this binary is being compiled for, which for `build.rs` is always the **host**; you need to use environment variables instead.