### PR TITLE
macOS: filter visible windows and capture window names

### DIFF
--- a/frontend/src/server.d.ts
+++ b/frontend/src/server.d.ts
@@ -9,6 +9,7 @@ type InternalFetcher = string
 export type EventData =
 	| { data_type: "x11_v2"; data: X11EventData }
 	| { data_type: "windows_v1"; data: WindowsEventData }
+	| { data_type: "macos_v1"; data: MacOSEventData }
 	| { data_type: "app_usage_v2"; data: AppUsageEntry }
 	| { data_type: "journald_v1"; data: JournaldEntry }
 	| { data_type: "sleep_as_android_v1"; data: SleepAsAndroidEntry }
@@ -56,6 +57,30 @@ export type WifiInterface = {
 	average_signal: number
 	bssid: string
 	connected_time: number
+}
+export type MacOSEventData = {
+	os_info: OsInfo
+	duration_since_user_input: { secs: number; nanos: number }
+	focused_window: number | null
+	windows: MacOSWindow[]
+}
+export type MacOSWindow = {
+	window_id: number
+	title: string | null
+	process: MacOSProcessData | null
+}
+export type MacOSProcessData = {
+	pid: number
+	name: string
+	bundle: string | null
+	cmd: string[]
+	exe: string
+	cwd: string
+	memory_kB: number
+	parent: number | null
+	status: string
+	start_time: DateTime<Utc>
+	cpu_usage: number | null
 }
 export type OsInfo = {
 	os_type: string

--- a/src/bin/timetrackrs.rs
+++ b/src/bin/timetrackrs.rs
@@ -3,8 +3,8 @@
 
 use std::path::PathBuf;
 
+use futures::StreamExt;
 use futures::{never::Never, stream::FuturesUnordered};
-use futures::{StreamExt, TryStreamExt};
 
 use timetrackrs::{config::TimetrackrsConfig, prelude::*};
 use timetrackrs::{db::clear_wal_files, util::init_logging};

--- a/src/bin/trbtt-typescript-gen.rs
+++ b/src/bin/trbtt-typescript-gen.rs
@@ -1,4 +1,5 @@
 use std::io::prelude::*;
+use std::process::Command;
 use timetrackrs::capture::*;
 
 use timetrackrs::prelude::*;
@@ -16,6 +17,9 @@ const FS: &[fn() -> std::borrow::Cow<'static, str>] = &[
     linux::types::ProcessData::type_script_ify,
     linux::types::NetworkInfo::type_script_ify,
     linux::types::WifiInterface::type_script_ify,
+    macos::types::MacOSEventData::type_script_ify,
+    macos::types::MacOSWindow::type_script_ify,
+    macos::types::MacOSProcessData::type_script_ify,
     util::OsInfo::type_script_ify,
     TagRuleGroup::type_script_ify,
     TagRuleGroupData::type_script_ify,
@@ -64,6 +68,11 @@ fn main() -> anyhow::Result<()> {
         for f in FS {
             writeln!(ofile, "{}", f())?;
         }
+        drop(ofile);
+        Command::new("yarn")
+            .args(["prettier", "--write", "src/server.d.ts"])
+            .current_dir("./frontend")
+            .status()?;
         println!("output {} types", FS.len());
     } else {
         println!("NOT IN DEBUG MODE, will not work!")

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -76,7 +76,7 @@ impl From<&Timestamptz> for Timestamptz {
 
 impl Serialize for Timestamptz {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        use serde::ser::{Serialize, SerializeStruct, Serializer};
+        use serde::ser::SerializeStruct;
         let mut s = serializer.serialize_struct("Timestamptz", 2)?;
         s.serialize_field("$type", "Instant")?;
         s.serialize_field("unix_timestamp_ms", &self.0.timestamp_millis())?;


### PR DESCRIPTION
Hi, I tested the macOS capture. The window name being none is not because it's not there, but it's protected by macOS security layer. We need to request permission ahead of time to get the window name. As I tested in my local machine, it now works fine.

And also, I add a prettier step for typescript type gen. The implementation may not mature, e.g. it assumes yarn and prettier being installed and CWD is in the project root.

My Rust experience is very limited, so please leave comments if I make things wrong.

ref: 
- https://developer.apple.com/videos/play/wwdc2019/701/?time=1007
- https://developer.apple.com/documentation/coregraphics/3656524-cgrequestscreencaptureaccess
